### PR TITLE
fix the issue of stackHist

### DIFF
--- a/StackPlotScript.py
+++ b/StackPlotScript.py
@@ -51,6 +51,9 @@ for sL in samplesRun:
     if 'Data' in sL:
         sLi = sL.replace('Data','')+'Run'
         bashline.append('hadd StackHist_%s.root StackHist_%s*.root\n'%(sL, sLi))
+    elif isinstance(samplelist[sL][0], types.ListType):
+        sLi = 'hadd StackHist_'+sL+'.root'+str("".join(' StackHist_'+list(samplelist.keys())[list(samplelist.values()).index(s)]+'*.root' for s in samplelist[sL]))
+        bashline.append('%s\n'%sLi)
     else:
         bashline.append('hadd StackHist_%s.root StackHist_%s_*.root\n'%(sL, sL))
     bashline.append('mv StackHist_%s.root %s\n'%(sL, Rootfilesdirpath))

--- a/VarHandler.py
+++ b/VarHandler.py
@@ -278,7 +278,7 @@ class VarHandler():
     def genEle(self):
         L = []
         for i in range(self.tr.nGenPart):
-            if abs(self.tr.GenPart_pdgId[i]) ==11 and GenFlagString(self.tr.GenPart_statusFlags[i])[-1]=='1' and GenFlagString(self.tr.GenPart_statusFlags[i])[6]=='1' and self.tr.GenPart_status[i]==1 and self.tr.GenPart_genPartIdxMother[i] != -1:
+            if abs(self.tr.GenPart_pdgId[i]) ==11 and GenFlagString(self.tr.GenPart_statusFlags[i])[-1]=='1' and GenFlagString(self.tr.GenPart_statusFlags[i])[6]=='1' and self.tr.GenPart_status[i]==1 and self.tr.GenPart_genPartIdxMother[i] >= 0:
                 if abs(self.tr.GenPart_pdgId[self.tr.GenPart_genPartIdxMother[i]])!=21:
                     L.append({'pt':self.tr.GenPart_pt[i], 'eta':self.tr.GenPart_eta[i], 'phi':self.tr.GenPart_phi[i]})
         return L
@@ -286,7 +286,7 @@ class VarHandler():
     def genMuon(self):
         L = []
         for i in range(self.tr.nGenPart):
-            if abs(self.tr.GenPart_pdgId[i]) ==13 and GenFlagString(self.tr.GenPart_statusFlags[i])[-1]=='1' and GenFlagString(self.tr.GenPart_statusFlags[i])[6]=='1' and self.tr.GenPart_status[i]==1 and self.tr.GenPart_genPartIdxMother[i] != -1:
+            if abs(self.tr.GenPart_pdgId[i]) ==13 and GenFlagString(self.tr.GenPart_statusFlags[i])[-1]=='1' and GenFlagString(self.tr.GenPart_statusFlags[i])[6]=='1' and self.tr.GenPart_status[i]==1 and self.tr.GenPart_genPartIdxMother[i] >= 0:
                 if abs(self.tr.GenPart_pdgId[self.tr.GenPart_genPartIdxMother[i]])!=22:
                     L.append({'pt':self.tr.GenPart_pt[i], 'eta':self.tr.GenPart_eta[i], 'phi':self.tr.GenPart_phi[i]})
         return L
@@ -294,7 +294,7 @@ class VarHandler():
     def genB(self):
         L = []
         for i in range(self.tr.nGenPart):
-            if abs(self.tr.GenPart_pdgId[i]) ==5 and self.tr.GenPart_genPartIdxMother[i] != -1 and self.tr.GenPart_genPartIdxMother[i]<self.tr.nGenPart:
+            if abs(self.tr.GenPart_pdgId[i]) ==5 and self.tr.GenPart_genPartIdxMother[i] >=0 and self.tr.GenPart_genPartIdxMother[i]<self.tr.nGenPart:
                 if abs(self.tr.GenPart_pdgId[self.tr.GenPart_genPartIdxMother[i]])==1000006 and self.tr.GenPart_statusFlags[self.tr.GenPart_genPartIdxMother[i]]==10497:
                         L.append({'pt':self.tr.GenPart_pt[i], 'eta':self.tr.GenPart_eta[i], 'phi':self.tr.GenPart_phi[i]})
         
@@ -310,7 +310,7 @@ class VarHandler():
     def genLSP(self):
         L = []
         for i in range(self.tr.nGenPart):
-            if abs(self.tr.GenPart_pdgId[i]) ==1000022 and self.tr.GenPart_genPartIdxMother[i] != -1:
+            if abs(self.tr.GenPart_pdgId[i]) ==1000022 and self.tr.GenPart_genPartIdxMother[i] >= 0:
                 if abs(self.tr.GenPart_pdgId[self.tr.GenPart_genPartIdxMother[i]])==1000006 and self.tr.GenPart_statusFlags[self.tr.GenPart_genPartIdxMother[i]]==10497:
                     L.append({'pt':self.tr.GenPart_pt[i], 'eta':self.tr.GenPart_eta[i], 'phi':self.tr.GenPart_phi[i]})
         return L


### PR DESCRIPTION
The error in running StackPlotScript.py with a few SM samples was occurring due to the error in doing hadd for those samples.
As the subsample name does not match with sample name (ex: https://github.com/1LStopBudapest/Sample/blob/master/FileList_2016.py#L35). hadd can not find the subsamples root files. Its fixed now in StackPlotScript.py script.
Running StackHistMaker.py for DYJetsToLL samples was giving error due to the genMuon function had a bug regarding the mother idx value. It fixed now